### PR TITLE
GCAM to Demeter: land allocation xml query

### DIFF
--- a/gcam_to_demeter/land_allocation.xml
+++ b/gcam_to_demeter/land_allocation.xml
@@ -1,0 +1,6 @@
+<query title="detailed land allocation">
+    <axis1 name="LandLeaf">LandLeaf[@name]</axis1>
+    <axis2 name="Year">land-allocation[@year]</axis2>
+    <xPath buildList="true" dataName="LandLeaf" group="false" sumAll="false">/LandNode[@name='root' or @type='LandNode' (:collapse:)]//land-allocation/text()</xPath>
+    <comments/>
+</query>


### PR DESCRIPTION
**GCAM to Demeter: land allocation xml query**

This query is used to extract detailed land allocation by:  region, basin, land class, and year.

**GCAM-USA version**:  5.3 (IM3 version)

**Expected land area units from GCAM**:  thousands km<sup>2</sup>

**Expected fields**:  

| field_name | data_type | description | 
| ----------- | ---------- | ------------ | 
|`Units` | str | GCAM land units| 
| `scenario` | str | GCAM scenario name | 
| `region` | str | GCAM geopolitical region | 
| `LandLeaf ` | str | GCAM land class name in `<crop>_<basin>_<irr-or-rfd>_<mgmt>` format  | 
| `Year` | int | GCAM year |
| `value` | float | GCAM land allocation value in  thousands km<sup>2</sup>

**Meta-Issue**:  #1 