### PR TITLE
GCAM-USA to GO: Fuel Costs by fuel type, vintage, and state

### DIFF
--- a/gcam_to_go/README.MD
+++ b/gcam_to_go/README.MD
@@ -18,19 +18,12 @@ Documentation and scripts for data extraction, formatting, and calculation input
 
 ## Data Requirements for GO from GCAM-USA
 
-For every:
-* Scenario 
-* Vintage (Vint_{year})
-* Year (x)
-* Technology (class2)
-* subregion (state)
-
 GO needs the following information:
 
-|Source|Description|Output Variable Name|GCAM Query/File Path(s)|Original Units|Output Units|
-|------------------|-------------------|--|--|--|--|
-|GCAM output        |Technology Heat Rate           |elec_heat_rate_BTUperkWh       |"elec coeff"                       |?|btu/kWh|
-|GCAM output        |Technology Fuel Price          |elec_fuel_price_2015USDperMBTU |"prices by sector"                 |1975USD/GJ|$2015USD/MBTU|
+| GO Variable | GO Variable Name | Description | GO Required Units |
+|---------------|--------------------|-------------|---------------------|
+| Heat rate by tech | elec_heat_rate_BTUperkWh | Heat rate by technology (inclusive of cooling type), state, vintage, and scenario | btu/kWh | | |
+| Fuel price by tech | elec_fuel_price_2015USDperMBTU | Fuel price by fuel type, state, vintage, and scenario | $2015USD/MBTU | | |
 
 
 ## Expected Output Data Format
@@ -46,8 +39,6 @@ A single .csv file is the expected format of this data extraction effort. The cs
 | param          | parameter name                    | str | elec_heat_rate_BTUperkWh   |
 | classLabel1    | describes class1 variable         | str | subsector                |
 | class1         | tech category                     | str | biomass                |
-| classLabel2    | describes class2 variable         | str | technology                |
-| class2         | full tech name with cooling type  | str | biomass (conv) (cooling pond) |
 | xlabel         | describes x variable              | str | Year |
 | x              | year of parameter value           | int | 2025 |
 | vintage        | gcam simulation year of parameter | str | Vint_2020 |
@@ -119,7 +110,9 @@ This time series is the BEA "A191RD3A086NBEA" product from https://fred.stlouisf
 
 ### elec_fuel_price_2015USDperMBTU
 
-* **Description:** Fuel price for natural gas, oil, coal, and biomass technologies by vintage and region. Biomass ("regional biomass") is provided at the regional level, fossil fuels ("refined liquids industrial", "regional coal", and "wholesale gas") are provided at the grid region level. These each need to be mapped to states and to all appropriate technologies. GCAM prices are provided in 1975 USD and need to be scaled to 2015 USD. Last, prices must be converted from $/GJ to $/MBTU. Unit conversion from https://www.unitconverters.net/energy/gigajoule-to-mega-btu-it.htm
+* **Description:** Fuel price for natural gas, oil, coal, nuclear, and biomass by vintage and state. Biomass ("regional biomass") is provided at the state level, fossil fuels ("refined liquids industrial", "regional coal", and "wholesale gas") are provided at the grid region level, nuclear fuel is provided at the US aggregate level. These each need to be mapped to individual states. 
+
+GCAM prices are provided in 1975 USD and need to be scaled to 2015 USD. Last, prices must be converted from $/GJ to $/MBTU. Unit conversion from https://www.unitconverters.net/energy/gigajoule-to-mega-btu-it.htm
 * **gcam query:** "prices by sector"
 * **Original units:** 1975USD/GJ
 * **Output units:** $2015USD/MBTU

--- a/gcam_to_go/README.MD
+++ b/gcam_to_go/README.MD
@@ -113,7 +113,7 @@ This time series is the BEA "A191RD3A086NBEA" product from https://fred.stlouisf
 * **Description:** Fuel price for natural gas, oil, coal, nuclear, and biomass by vintage and state. Biomass ("regional biomass") is provided at the state level, fossil fuels ("refined liquids industrial", "regional coal", and "wholesale gas") are provided at the grid region level, nuclear fuel is provided at the US aggregate level. These each need to be mapped to individual states. 
 
 GCAM prices are provided in 1975 USD and need to be scaled to 2015 USD. Last, prices must be converted from $/GJ to $/MBTU. Unit conversion from https://www.unitconverters.net/energy/gigajoule-to-mega-btu-it.htm
-* **gcam query:** "prices by sector"
+* **gcam query:** 'prices of all markets'
 * **Original units:** 1975USD/GJ
 * **Output units:** $2015USD/MBTU
 * **Calculation:**

--- a/gcam_to_go/elec_queries.xml
+++ b/gcam_to_go/elec_queries.xml
@@ -1,0 +1,395 @@
+<?xml version="1.0"?>
+<queries>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+                    <supplyDemandQuery title="elec capacity by tech and vintage">
+                        <axis1 name="technology">technology</axis1>
+                        <axis2 name="Year">capacity[@vintage]</axis2>
+                        <xPath buildList="true" dataName="capacity" group="false" sumAll="false">*[@type = 'sector' (: collapse :) and (@name='electricity')]//*[@type = 'technology']/capacity/node()</xPath>
+                        <comments/>
+                        <showAttribute attribute-name="year" level="technology"/>
+                    </supplyDemandQuery>
+   </aQuery>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+                    <supplyDemandQuery title="elec gen by gen tech and cooling tech and vintage (incl cogen)">
+                        <axis1 name="technology">technology</axis1>
+                        <axis2 name="Year">physical-output[@vintage]</axis2>
+                        <xPath buildList="true" dataName="output" group="false" sumAll="false">
+                  *[@type='sector' (:collapse:) and (@name='electricity' or @name='elect_td_bld' or @name='industrial energy use')]/
+                  *[@type='subsector']/*[@type='technology' and not (@name='electricity' or @name='elect_td_bld')]/
+                  *[@type='output' (:collapse:) and (@name='electricity' or @name='elect_td_bld' or ( contains( @name, 'electricity_')))]/
+                  physical-output/node()</xPath>
+                        <comments/>
+                        <showAttribute attribute-name="year" level="technology"/>
+                    </supplyDemandQuery>
+   </aQuery>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+                     <supplyDemandQuery title="elec coefs by tech">
+                        <axis1 name="input">input</axis1>
+                        <axis2 name="Year">IO-coefficient[@vintage]</axis2>
+                <xPath buildList="true" dataName="input" group="false" sumAll="false">*[@type='sector' and (@name='electricity')]/*[@type='subsector']//*[@type='technology']/*[@type='input']/IO-coefficient[
+               @vintage=parent::*/parent::*/@year]/node()</xPath>
+                <comments/>
+            </supplyDemandQuery>
+   </aQuery>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+                    <supplyDemandQuery title="elec costs by tech and vintage and input">
+                        <axis1 name="technology">technology</axis1>
+                        <axis2 name="Year">price-paid[@vintage]</axis2>
+                        <xPath buildList="true" dataName="fuel cost" group="false" sumAll="false">*[@type = 'sector' and (@name="electricity")]/*[@type = 'subsector']/*[@type = 'technology']/
+            *[@type='input']/price-paid[@vintage=parent::*/parent::*/@year]/text()</xPath>
+                        <comments>excludes energy and emissions related costs which are not printed</comments>
+                        <showAttribute attribute-name="year" level="technology"/>
+                    </supplyDemandQuery>
+   </aQuery>
+   <aQuery>
+  <region name="Alaska grid"/>
+  <region name="California grid"/>
+  <region name="Central East grid"/>
+  <region name="Central Northeast grid"/>
+  <region name="Central Northwest grid"/>
+  <region name="Central Southwest grid"/>
+  <region name="Florida grid"/>
+  <region name="Hawaii grid"/>
+  <region name="Mid-Atlantic grid"/>
+  <region name="New England grid"/>
+  <region name="New York grid"/>
+  <region name="Northwest grid"/>
+  <region name="Southeast grid"/>
+  <region name="Southwest grid"/>
+  <region name="Texas grid"/>
+  <region name="USA"/>
+            <marketQuery title="prices of all markets">
+                <axis1 name="market">market</axis1>
+                <axis2 name="Year">market</axis2>
+                <xPath buildList="true" dataName="price" group="false" sumAll="false">Marketplace/market[true()]/price/node()</xPath>
+                <comments/>
+            </marketQuery>
+   </aQuery>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+<supplyDemandQuery title="elec investment by investment segment (energy)">
+    <axis1 name="technology">technology</axis1>
+    <axis2 name="Year">physical-output[@vintage]</axis2>
+    <xPath buildList="true" dataName="output" group="false" sumAll="false">*[@type='sector' and
+               contains(@name, ' electricity')]//*[@type='technology']/
+               *[@type='output' (: collapse :)]/
+               physical-output/node()</xPath>
+    <comments/>
+</supplyDemandQuery>
+   </aQuery>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+<supplyDemandQuery title="elec investment capacity factor">
+    <axis1 name="technology">technology[@name]</axis1>
+    <axis2 name="Year">technology[@year]</axis2>
+    <xPath buildList="true" dataName="output" group="false" sumAll="false">*[@type='sector' and
+               contains(@name, ' electricity')]//*[@type='technology']/
+               capacity-factor/node()</xPath>
+    <comments/>
+</supplyDemandQuery>
+   </aQuery>
+</queries>

--- a/gcam_to_go/gdp_deflator.py
+++ b/gcam_to_go/gdp_deflator.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+def deflate_gdp(
+      year:int, 
+      base_year:int
+      ):
+    """
+    Some GCAM-USA variables are provided in 1975$ and need to be converted to 2015$. 
+    The function below allows for conversion between price years of GCAM parameters. 
+    This time series is the BEA "A191RD3A086NBEA" product from https://fred.stlouisfed.org/series/A191RD3A086NBEA
+
+    """
+
+    start_year = 1929
+    factors = np.array([
+        9.896, 9.535, 8.555, 7.553, 7.345, 7.749, 7.908, 8.001, 8.347,
+        8.109, 8.033, 8.131, 8.68, 9.369, 9.795, 10.027, 10.288, 11.618,
+        12.887, 13.605, 13.581, 13.745, 14.716, 14.972, 15.157, 15.298,
+        15.559, 16.091, 16.625, 17.001, 17.237, 17.476, 17.669, 17.886,
+        18.088, 18.366, 18.702, 19.227, 19.786, 20.627, 21.642, 22.784,
+        23.941, 24.978, 26.337, 28.703, 31.361, 33.083, 35.135, 37.602,
+        40.706, 44.377, 48.52, 51.53, 53.565, 55.466, 57.24, 58.395,
+        59.885, 61.982, 64.392, 66.773, 68.996, 70.569, 72.248, 73.785,
+        75.324, 76.699, 78.012, 78.859, 80.065, 81.887, 83.754, 85.039,
+        86.735, 89.12, 91.988, 94.814, 97.337, 99.246, 100, 101.221,
+        103.311, 105.214, 106.913, 108.828, 109.998, 111.445, 113.545,
+        116.311, 118.339
+    ])
+    return factors[year - start_year] / factors[base_year - start_year]
+
+def _deflate_gdp(year, base_year):
+  deflate_gdp(year, base_year)
+
+
+if __name__ == "__main__":
+  _deflate_gdp()

--- a/gcam_to_go/get_go_fuel_prices.py
+++ b/gcam_to_go/get_go_fuel_prices.py
@@ -1,0 +1,141 @@
+import gcamreader
+import numpy as np
+import pandas as pd
+from pathlib import Path
+from standardize_output_format import *
+from gdp_deflator import *
+from region_to_states import *
+import os
+
+# get a list of all available states
+ALL_STATES = sorted([s for states in REGION_TO_STATES.values() for s in states])
+
+def grid_region_to_state(df) -> pd.DataFrame:
+    def region_to_list(r):
+        if r in REGION_TO_STATES:
+            return REGION_TO_STATES[r]
+        else:
+            return [r]
+    df['region'] = df.region.apply(region_to_list)
+    df = df.explode('region', ignore_index=True)
+    return df
+
+def country_to_state(df) -> pd.DataFrame:
+    def region_to_list(r):
+        if r in COUNTRY_TO_STATES:
+            return COUNTRY_TO_STATES[r]
+        else:
+            return [r]
+    df['region'] = df.region.apply(region_to_list)
+    df = df.explode('region', ignore_index=True)
+    return df
+
+
+def get_query_by_name(queries, name):
+    return next((x for x in queries if x.title == name), None)
+
+
+def get_go_fuel_prices(
+    path_to_gcam_database:str,
+    gcam_file_name:str,
+    gcam_scenario:str,
+    save_output=False,
+    gcam_query_name='prices of all markets',
+    path_to_query_file: str = './elec_queries.xml',
+    ):
+
+    # set up unit conversions
+    GIGAJOULES_TO_MEGA_BRITISH_THERMAL_UNITS = 0.947817120
+
+    # create a Path from str
+    db_path = Path(path_to_gcam_database)
+
+    # create connection to gcam db
+    conn = gcamreader.LocalDBConn(db_path, gcam_file_name)
+
+    # parse the queries file
+    queries = gcamreader.parse_batch_query(path_to_query_file)
+
+    # collect fuel price data
+    fuel_prices = conn.runQuery(get_query_by_name(queries, gcam_query_name))
+
+    # regional biomass is provided at state level
+    bio = fuel_prices[(fuel_prices.market.str.contains('regional biomass')) & (~fuel_prices.market.str.contains('Oil'))].copy()
+    bio['fuel_type'] = 'regional biomass'
+    bio['region'] = bio['market'].astype(str).str[:2]
+    bio = bio[bio.region.isin(ALL_STATES)]
+
+    # nuclear is provided at US aggregate level and must be split out to all states
+    nuclear = fuel_prices[(fuel_prices.market.str.contains('USAnuclearFuelGenII|USAnuclearFuelGenIII'))].copy()
+    nuclear['fuel_type'] = nuclear.market.astype(str).str[3:]
+    nuclear['region'] = 'USA'
+    nuclear = country_to_state(nuclear)
+
+    # create a list of grid regions
+    i=0
+    for grid_region in REGION_TO_STATES.keys():
+        if i ==0:
+            grid_region_list =  grid_region
+        else:
+            grid_region_list = grid_region_list + "|"+ grid_region
+        i+=1
+    fuel_list='refined liquids industrial|regional coal|wholesale gas'
+        
+    # all other fuels are provided at grid region level and must be split into appropriate states
+    other = fuel_prices[fuel_prices.market.str.contains(grid_region_list)].copy()
+    other = other[other.market.str.contains(fuel_list)].copy()
+    other['fuel_type'] =  other['market'].str.split('grid', expand=True)[1]
+    other['region'] = other['market'].str.split('grid', expand=True)[0] + 'grid'
+
+    # expand to all states
+    other = grid_region_to_state(other)
+
+    # recombine fuel dataframes
+    prices = pd.concat([bio, nuclear, other])
+
+    # convert $/GJ to $/MBTU (million btu)
+    prices['value'] = prices['value'] / GIGAJOULES_TO_MEGA_BRITISH_THERMAL_UNITS
+
+    # convert 1975$ to 2015$ following gdp_deflator
+    prices['value'] = prices['value'] * deflate_gdp(2015, 1975) 
+
+    # rename columns
+    prices.rename(columns={
+            'Year': 'x',
+            'region':'subRegion',
+            'fuel_type':'class1'
+            }, inplace=True)
+
+    # add columns
+    prices['param'] = 'elec_fuel_price_2015USDperMBTU'
+    prices['units'] = 'Fuel Cost (2015 USD/MBTU)'
+    prices['region'] = 'USA'
+    prices['scenario']  = gcam_scenario
+    prices['vintage'] = prices['x']
+    prices['xlabel'] = 'year'
+    prices['classLabel1'] = 'sector'
+
+    # select output 
+    prices = prices[['scenario', 'region', 'subRegion', 'param', 'classLabel1', 'class1', 'xlabel', 'x', 'vintage', 'units', 'value']]
+
+    if save_output:
+        os.makedirs(Path('./extracted_data'), exist_ok=True)
+        prices.to_csv(Path(f'./extracted_data/{gcam_scenario}_go_fuel_prices.csv'), index=False)
+    else:
+       pass
+
+def _get_go_fuel_prices(      
+        path_to_gcam_database,
+        gcam_file_name,
+        gcam_scenario
+        ):
+  
+  get_go_fuel_prices(
+        path_to_gcam_database,
+        gcam_file_name,
+        gcam_scenario
+  )
+
+
+if __name__ == "__main__":
+  _get_go_fuel_prices()

--- a/gcam_to_go/get_go_fuel_prices.py
+++ b/gcam_to_go/get_go_fuel_prices.py
@@ -2,7 +2,6 @@ import gcamreader
 import numpy as np
 import pandas as pd
 from pathlib import Path
-from standardize_output_format import *
 from gdp_deflator import *
 from region_to_states import *
 import os
@@ -111,18 +110,20 @@ def get_go_fuel_prices(
     prices['units'] = 'Fuel Cost (2015 USD/MBTU)'
     prices['region'] = 'USA'
     prices['scenario']  = gcam_scenario
-    prices['vintage'] = prices['x']
-    prices['xlabel'] = 'year'
+    prices['vintage'] = 'Vint_' + prices['x'].astype(str)
+    prices['xLabel'] = 'Year'
     prices['classLabel1'] = 'sector'
 
     # select output 
-    prices = prices[['scenario', 'region', 'subRegion', 'param', 'classLabel1', 'class1', 'xlabel', 'x', 'vintage', 'units', 'value']]
+    prices = prices[['scenario', 'region', 'subRegion', 'param', 'classLabel1', 'class1', 'xLabel', 'x', 'vintage', 'units', 'value']]
 
     if save_output:
         os.makedirs(Path('./extracted_data'), exist_ok=True)
         prices.to_csv(Path(f'./extracted_data/{gcam_scenario}_go_fuel_prices.csv'), index=False)
     else:
        pass
+
+    return prices
 
 def _get_go_fuel_prices(      
         path_to_gcam_database,

--- a/gcam_to_go/region_to_states.py
+++ b/gcam_to_go/region_to_states.py
@@ -1,0 +1,25 @@
+# maps GCAM-USA grid regions to individual states
+REGION_TO_STATES = {
+    "Alaska grid": ["AK"],
+    "California grid": ["CA"],
+    "Central East grid": ["IN", "KY", "MI", "OH", "WV"],
+    "Central Northeast grid": ["IL", "MO", "WI"],
+    "Central Northwest grid": ["IA", "MN", "ND", "NE", "SD"],
+    "Central Southwest grid": ["KS", "OK"],
+    "Florida grid": ["FL"],
+    "Hawaii grid": ["HI"],
+    "Mid-Atlantic grid": ["DC", "DE", "MD", "NJ", "PA"],
+    "New England grid": ["CT", "MA", "ME", "NH", "RI", "VT"],
+    "New York grid": ["NY"],
+    "Northwest grid": ["ID", "MT", "NV", "OR", "UT", "WA"],
+    "Southeast grid": ["AL", "AR", "GA", "LA", "MS", "NC", "SC", "TN", "VA"],
+    "Southwest grid": ["AZ", "CO", "NM", "WY"],
+    "Texas grid": ["TX"],
+}
+
+# map USA to individual states
+COUNTRY_TO_STATES = {
+    "USA": ["AK", "CA", "IN", "KY", "MI", "OH", "WV", "IL", "MO", "WI","IA", "MN", "ND", 
+            "NE", "SD", "KS", "OK", "FL", "HI", "DC", "DE", "MD", "NJ", "PA", "CT", "MA", 
+            "ME", "NH", "RI", "VT", "NY", "ID", "MT", "NV", "OR", "UT", "WA", "AL", "AR", 
+            "GA", "LA", "MS", "NC", "SC", "TN", "VA", "AZ", "CO", "NM", "WY", "TX"]}


### PR DESCRIPTION
**GCAM-USA to GO:** Fuel Costs by fuel type, vintage, and state

**GCAM-USA version:** 5.3 (IM3 version)

**Python script:** [get_go_fuel_prices.py](https://github.com/IMMM-SFA/gcam-usa_to_downstream-models/blob/go_get_fuel_costs/gcam_to_go/get_go_fuel_prices.py)

**Data Description:** [Fuel Costs](https://github.com/IMMM-SFA/gcam-usa_to_downstream-models/blob/go_get_fuel_costs/gcam_to_go/README.MD#elec_fuel_price_2015usdpermbtu)

**Meta-Issue:** https://github.com/IMMM-SFA/gcam-usa_to_downstream-models/issues/1