### PR TITLE
GCAM-USA to GO: Heat Rates by technology, vintage, and state

### DIFF
--- a/gcam_to_go/README.MD
+++ b/gcam_to_go/README.MD
@@ -18,13 +18,6 @@ Documentation and scripts for data extraction, formatting, and calculation input
 
 ## Data Requirements for GO from GCAM-USA
 
-For every:
-* Scenario 
-* Vintage (Vint_{year})
-* Year (x)
-* Technology (class2)
-* subregion (state)
-
 GO needs the following information:
 
 |Source|Description|Output Variable Name|GCAM Query/File Path(s)|Original Units|Output Units|
@@ -109,12 +102,19 @@ This time series is the BEA "A191RD3A086NBEA" product from https://fred.stlouisf
 
 ### elec_heat_rate_BTUperkWh
 
-* **Description:** Heat rate by technology, vintage, subregion, and year. Solar and wind heat rates should have a value of 0.
-* **gcam query:** "elec coeff"    
+* **Description:** Heat rate by technology, vintage, and state. GCAM-USA reports heat rates in EJ in / EJ out ratios. These need to be converted to BTU in / kWh out.
+
+* **gcam query:** "elec coefs by tech"   
 * **Original units:** 
 * **Output units:** btu/kWh
 * **Calculation:** 
+    BRITISH_THERMAL_UNITS_PER_EXAJOULE = 9.48e14
+    KWH_PER_EXAJOULE = 2.77778e11
 
+    Example:
+
+        1.2 EJ/EJ = (1.2 * BRITISH_THERMAL_UNITS_PER_EXAJOULE) / KWH_PER_EXAJOULE
+        = 4095.356 BTU/kWh
 
 
 ### elec_fuel_price_2015USDperMBTU

--- a/gcam_to_go/elec_queries.xml
+++ b/gcam_to_go/elec_queries.xml
@@ -1,0 +1,395 @@
+<?xml version="1.0"?>
+<queries>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+                    <supplyDemandQuery title="elec capacity by tech and vintage">
+                        <axis1 name="technology">technology</axis1>
+                        <axis2 name="Year">capacity[@vintage]</axis2>
+                        <xPath buildList="true" dataName="capacity" group="false" sumAll="false">*[@type = 'sector' (: collapse :) and (@name='electricity')]//*[@type = 'technology']/capacity/node()</xPath>
+                        <comments/>
+                        <showAttribute attribute-name="year" level="technology"/>
+                    </supplyDemandQuery>
+   </aQuery>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+                    <supplyDemandQuery title="elec gen by gen tech and cooling tech and vintage (incl cogen)">
+                        <axis1 name="technology">technology</axis1>
+                        <axis2 name="Year">physical-output[@vintage]</axis2>
+                        <xPath buildList="true" dataName="output" group="false" sumAll="false">
+                  *[@type='sector' (:collapse:) and (@name='electricity' or @name='elect_td_bld' or @name='industrial energy use')]/
+                  *[@type='subsector']/*[@type='technology' and not (@name='electricity' or @name='elect_td_bld')]/
+                  *[@type='output' (:collapse:) and (@name='electricity' or @name='elect_td_bld' or ( contains( @name, 'electricity_')))]/
+                  physical-output/node()</xPath>
+                        <comments/>
+                        <showAttribute attribute-name="year" level="technology"/>
+                    </supplyDemandQuery>
+   </aQuery>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+                     <supplyDemandQuery title="elec coefs by tech">
+                        <axis1 name="input">input</axis1>
+                        <axis2 name="Year">IO-coefficient[@vintage]</axis2>
+                <xPath buildList="true" dataName="input" group="false" sumAll="false">*[@type='sector' and (@name='electricity')]/*[@type='subsector']//*[@type='technology']/*[@type='input']/IO-coefficient[
+               @vintage=parent::*/parent::*/@year]/node()</xPath>
+                <comments/>
+            </supplyDemandQuery>
+   </aQuery>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+                    <supplyDemandQuery title="elec costs by tech and vintage and input">
+                        <axis1 name="technology">technology</axis1>
+                        <axis2 name="Year">price-paid[@vintage]</axis2>
+                        <xPath buildList="true" dataName="fuel cost" group="false" sumAll="false">*[@type = 'sector' and (@name="electricity")]/*[@type = 'subsector']/*[@type = 'technology']/
+            *[@type='input']/price-paid[@vintage=parent::*/parent::*/@year]/text()</xPath>
+                        <comments>excludes energy and emissions related costs which are not printed</comments>
+                        <showAttribute attribute-name="year" level="technology"/>
+                    </supplyDemandQuery>
+   </aQuery>
+   <aQuery>
+  <region name="Alaska grid"/>
+  <region name="California grid"/>
+  <region name="Central East grid"/>
+  <region name="Central Northeast grid"/>
+  <region name="Central Northwest grid"/>
+  <region name="Central Southwest grid"/>
+  <region name="Florida grid"/>
+  <region name="Hawaii grid"/>
+  <region name="Mid-Atlantic grid"/>
+  <region name="New England grid"/>
+  <region name="New York grid"/>
+  <region name="Northwest grid"/>
+  <region name="Southeast grid"/>
+  <region name="Southwest grid"/>
+  <region name="Texas grid"/>
+  <region name="USA"/>
+            <marketQuery title="prices of all markets">
+                <axis1 name="market">market</axis1>
+                <axis2 name="Year">market</axis2>
+                <xPath buildList="true" dataName="price" group="false" sumAll="false">Marketplace/market[true()]/price/node()</xPath>
+                <comments/>
+            </marketQuery>
+   </aQuery>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+<supplyDemandQuery title="elec investment by investment segment (energy)">
+    <axis1 name="technology">technology</axis1>
+    <axis2 name="Year">physical-output[@vintage]</axis2>
+    <xPath buildList="true" dataName="output" group="false" sumAll="false">*[@type='sector' and
+               contains(@name, ' electricity')]//*[@type='technology']/
+               *[@type='output' (: collapse :)]/
+               physical-output/node()</xPath>
+    <comments/>
+</supplyDemandQuery>
+   </aQuery>
+   <aQuery>
+      <region name = "AK"/>
+      <region name = "AL"/>
+      <region name = "AR"/>
+      <region name = "AZ"/>
+      <region name = "CA"/>
+      <region name = "CO"/>
+      <region name = "CT"/>
+      <region name = "DC"/>
+      <region name = "DE"/>
+      <region name = "FL"/>
+      <region name = "GA"/>
+      <region name = "HI"/>
+      <region name = "IA"/>
+      <region name = "ID"/>
+      <region name = "IL"/>
+      <region name = "IN"/>
+      <region name = "KS"/>
+      <region name = "KY"/>
+      <region name = "LA"/>
+      <region name = "MA"/>
+      <region name = "MD"/>
+      <region name = "ME"/>
+      <region name = "MI"/>
+      <region name = "MN"/>
+      <region name = "MO"/>
+      <region name = "MS"/>
+      <region name = "MT"/>
+      <region name = "NC"/>
+      <region name = "ND"/>
+      <region name = "NE"/>
+      <region name = "NH"/>
+      <region name = "NJ"/>
+      <region name = "NM"/>
+      <region name = "NV"/>
+      <region name = "NY"/>
+      <region name = "OH"/>
+      <region name = "OK"/>
+      <region name = "OR"/>
+      <region name = "PA"/>
+      <region name = "RI"/>
+      <region name = "SC"/>
+      <region name = "SD"/>
+      <region name = "TN"/>
+      <region name = "TX"/>
+      <region name = "UT"/>
+      <region name = "VA"/>
+      <region name = "VT"/>
+      <region name = "WA"/>
+      <region name = "WI"/>
+      <region name = "WV"/>
+      <region name = "WY"/>
+<supplyDemandQuery title="elec investment capacity factor">
+    <axis1 name="technology">technology[@name]</axis1>
+    <axis2 name="Year">technology[@year]</axis2>
+    <xPath buildList="true" dataName="output" group="false" sumAll="false">*[@type='sector' and
+               contains(@name, ' electricity')]//*[@type='technology']/
+               capacity-factor/node()</xPath>
+    <comments/>
+</supplyDemandQuery>
+   </aQuery>
+</queries>

--- a/gcam_to_go/get_go_heat_rate.py
+++ b/gcam_to_go/get_go_heat_rate.py
@@ -56,12 +56,12 @@ def get_go_heat_rate(
     heat_rate['region'] = 'USA'
     heat_rate['scenario']  = gcam_scenario
     heat_rate['vintage'] = heat_rate['x']
-    heat_rate['xlabel'] = 'year'
+    heat_rate['xLabel'] = 'year'
     heat_rate['classLabel2'] = 'technology'
 
     # reduce columns
     heat_rate = heat_rate[['scenario', 'region', 'subRegion', 'param', 'classLabel2' ,
-                        'class2', 'xlabel', 'x', 'vintage', 'units', 'value']].reset_index(drop=True)
+                        'class2', 'xLabel', 'x', 'vintage', 'units', 'value']].reset_index(drop=True)
 
     if save_output:
         os.makedirs(Path('./extracted_data'), exist_ok=True)

--- a/gcam_to_go/get_go_heat_rate.py
+++ b/gcam_to_go/get_go_heat_rate.py
@@ -1,0 +1,89 @@
+import gcamreader
+import numpy as np
+import pandas as pd
+from pathlib import Path
+import os
+
+
+def get_query_by_name(queries, name):
+    return next((x for x in queries if x.title == name), None)
+
+
+def get_go_heat_rate(
+    path_to_gcam_database:str,
+    gcam_file_name:str,
+    gcam_scenario:str,
+    save_output=False,
+    gcam_query_name = "elec coefs by tech",
+    path_to_query_file: str = './elec_queries.xml',
+    ):
+
+    # set up unit conversions
+    BRITISH_THERMAL_UNITS_PER_EXAJOULE = 9.48e14
+    KWH_PER_EXAJOULE = 2.77778e11
+
+    # create a Path from str
+    db_path = Path(path_to_gcam_database)
+
+    # create connection to gcam db
+    conn = gcamreader.LocalDBConn(db_path, gcam_file_name)
+
+    # parse the queries file
+    queries = gcamreader.parse_batch_query(path_to_query_file)
+
+    # heat rate is based on technology and input fuel
+    heat_rate = conn.runQuery(get_query_by_name(queries, gcam_query_name))
+
+    # select required fuels
+    fuels = ['nuclearFuelGenII', 'nuclearFuelGenIII', 'refined liquids industrial', 'regional biomass', 'regional coal', 'wholesale gas']
+    heat_rate = heat_rate[heat_rate.input.isin(fuels)]
+
+    # convert EJ in per EJ out to BTU in per kwh out
+    heat_rate['value'] = (heat_rate['value'] * BRITISH_THERMAL_UNITS_PER_EXAJOULE) / KWH_PER_EXAJOULE
+
+    # rename columns
+    heat_rate.rename(columns={
+        'Units': 'units',
+        'Year': 'x',
+        'input': 'fuel_type',
+        'technology':'class2',
+        'region':'subRegion'
+    }, inplace=True)
+
+    # add columns
+    heat_rate['param'] = 'elec_heat_rate_BTUperkWh'
+    heat_rate['units'] = 'Heat Rate (BTU per kWh)'
+    heat_rate['region'] = 'USA'
+    heat_rate['scenario']  = gcam_scenario
+    heat_rate['vintage'] = heat_rate['x']
+    heat_rate['xlabel'] = 'year'
+    heat_rate['classLabel2'] = 'technology'
+
+    # reduce columns
+    heat_rate = heat_rate[['scenario', 'region', 'subRegion', 'param', 'classLabel2' ,
+                        'class2', 'xlabel', 'x', 'vintage', 'units', 'value']].reset_index(drop=True)
+
+    if save_output:
+        os.makedirs(Path('./extracted_data'), exist_ok=True)
+        heat_rate.to_csv(Path(f'./extracted_data/{gcam_scenario}_go_heat_rates.csv'), index=False)
+    else:
+       pass
+
+    return heat_rate
+
+
+def _get_go_heat_rate(
+      path_to_gcam_database,
+      gcam_file_name,
+      gcam_scenario
+      ):
+  
+  get_go_heat_rate(
+      path_to_gcam_database,
+      gcam_file_name,
+      gcam_scenario
+      )
+
+
+if __name__ == "__main__":
+  _get_go_heat_rate()


### PR DESCRIPTION
**GCAM-USA to GO:** Heat Rates by technology, vintage, and state

**GCAM-USA version:** 5.3 (IM3 version)

**Python script:** [get_go_heat_rates.py](https://github.com/IMMM-SFA/gcam-usa_to_downstream-models/blob/go_get_heat_rates/gcam_to_go/get_go_heat_rate.py)

**Data Description:** [Heat Rates by Technology](https://github.com/IMMM-SFA/gcam-usa_to_downstream-models/blob/go_get_heat_rates/gcam_to_go/README.MD#elec_heat_rate_btuperkwh)

**Meta-Issue:** https://github.com/IMMM-SFA/gcam-usa_to_downstream-models/issues/1