### PR TITLE
GCAM-USA to CERF: Carbon price by year xml query 

### DIFF
--- a/gcam_to_cerf/README.MD
+++ b/gcam_to_cerf/README.MD
@@ -349,5 +349,21 @@ The escalation rate of variable O&M prices for each technology between years. Th
 
      Escalation Rate = (VOM_t - VOM_t-5) / VOM_t-5
 
+_____________
 
+<br>
 
+### 10. Carbon Price by Year
+The cost incurred per ton of carbon for fossil-fuel generation technologies.
+#### CERF Variable Name: 
+* carbon_price_2015USDperTonCarbon
+#### CERF required units:
+* $2015/tonCarbon
+#### Calculations & Transformations Required:
+GCAM prices are provided in 1990 USD and need to be converted to 2015 USD. Carbon price is provided as a global variable by year. This needs to be mapped to all technologies, states, and years with new capacity.
+* **Unit Conversion** 
+
+None
+* **1975 to 2015 Dollar Year Conversion** 
+
+        carbon_price_2015USDperTonCarbon = (carbon_price_1990USDperTonCarbon * gdp_deflator(2015,1990))

--- a/gcam_to_cerf/README.MD
+++ b/gcam_to_cerf/README.MD
@@ -364,6 +364,6 @@ GCAM prices are provided in 1990 USD and need to be converted to 2015 USD. Carbo
 * **Unit Conversion** 
 
 None
-* **1975 to 2015 Dollar Year Conversion** 
+* **1990 to 2015 Dollar Year Conversion** 
 
         carbon_price_2015USDperTonCarbon = (carbon_price_1990USDperTonCarbon * gdp_deflator(2015,1990))

--- a/gcam_to_cerf/get_carbon_price.py
+++ b/gcam_to_cerf/get_carbon_price.py
@@ -43,6 +43,9 @@ def get_carbon_price(
     # map to new capacity rows by year to apply to all technologies, all states, and all years
     carbon_price = pd.merge(capacity_crosscheck, carbon_price, how='left', on=['x'])
 
+    # fill in missing carbon prices with zero for scenarios and/or model years which do not have a carbon policy active.
+    carbon_price['value'].fillna(0, inplace=True)
+
     # fill in missing columns
     carbon_price['units'] = 'Carbon Price (2015 USD/tonCarbon)'
     carbon_price['param'] = 'carbon_price_2015USDperTonCarbon'

--- a/gcam_to_cerf/get_carbon_price.py
+++ b/gcam_to_cerf/get_carbon_price.py
@@ -1,0 +1,71 @@
+import gcamreader
+import numpy as np
+import pandas as pd
+from pathlib import Path
+from gdp_deflator import *
+import os
+
+def get_query_by_name(queries, name):
+    return next((x for x in queries if x.title == name), None)
+
+def get_carbon_price(
+    path_to_gcam_database:str,
+    gcam_file_name:str,
+    gcam_scenario:str,
+    capacity_crosscheck:pd.DataFrame, 
+    save_output=False,
+    gcam_query_name = "CO2 prices",
+    path_to_query_file: str = './elec_queries.xml',
+    ):
+    # create connection to gcam db
+    conn = gcamreader.LocalDBConn(path_to_gcam_database, gcam_file_name)
+    
+    # parse the queries file
+    queries = gcamreader.parse_batch_query(path_to_query_file)
+    
+    # collect dataframe
+    carbon_price = conn.runQuery(get_query_by_name(queries, gcam_query_name))
+
+    # select correct market
+    carbon_price = carbon_price[carbon_price.market == 'globalCO2']
+
+    # convert 1990$ to 2015$ following gdp_deflator
+    carbon_price['value'] = carbon_price['value'] * deflate_gdp(2015, 1990)
+
+    # drop variables no longer needed
+    carbon_price = carbon_price.drop(['scenario', 'market', 'Units'], axis=1)
+
+    # rename column
+    carbon_price.rename(columns={
+            'Year': 'x',
+            }, inplace=True)
+
+    # map to new capacity rows by year to apply to all technologies, all states, and all years
+    carbon_price = pd.merge(capacity_crosscheck, carbon_price, how='left', on=['x'])
+
+    # fill in missing columns
+    carbon_price['units'] = 'Carbon Price (2015 USD/tonCarbon)'
+    carbon_price['param'] = 'carbon_price_2015USDperTonCarbon'
+
+    if save_output:
+        os.makedirs(Path('./extracted_data'), exist_ok=True)
+        carbon_price.to_csv(Path(f'./extracted_data/{gcam_scenario}_carbon_price.csv'), index=False)
+    else:
+       pass
+
+    return carbon_price
+
+
+def _get_carbon_price(
+      path_to_gcam_database,
+      gcam_file_name,
+      gcam_scenario):
+  
+  get_carbon_price(
+     path_to_gcam_database,
+     gcam_file_name,
+     gcam_scenario)
+
+
+if __name__ == "__main__":
+  _get_carbon_price()


### PR DESCRIPTION
**GCAM-USA to CERF:** Carbon prices by year xml query

**GCAM-USA version:** 5.3 (IM3 version)

**Python script:** [get_carbon_price.py](https://github.com/IMMM-SFA/gcam-usa_to_downstream-models/blob/cerf_get_carbon_price/gcam_to_cerf/get_carbon_price.py)

**Data Description:** [Carbon Price by Year](https://github.com/IMMM-SFA/gcam-usa_to_downstream-models/tree/cerf_get_carbon_price/gcam_to_cerf#10-carbon-price-by-year)

**Meta-Issue:** https://github.com/IMMM-SFA/gcam-usa_to_downstream-models/issues/1